### PR TITLE
Changed Perl module source URLs.

### DIFF
--- a/p/Perl/Perl-5.34.1-GCCcore-11.3.0.eb
+++ b/p/Perl/Perl-5.34.1-GCCcore-11.3.0.eb
@@ -7,7 +7,7 @@ description = """Larry Wall's Practical Extraction and Report Language"""
 toolchain = {'name': 'GCCcore', 'version': '11.3.0'}
 toolchainopts = {'pic': True}
 
-source_urls = ['https://www.cpan.org/src/%(version_major)s.0']
+source_urls = ['https://cpan.metacpan.org/src/%(version_major)s.0']
 sources = ['perl-%(version)s.tar.gz']
 checksums = ['357951a491b0ba1ce3611263922feec78ccd581dddc24a446b033e25acf242a1']
 
@@ -110,47 +110,47 @@ exts_list = [
     }),
     ('IPC::System::Simple', '1.30', {
         'source_tmpl': 'IPC-System-Simple-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/J/JK/JKEENAN/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/J/JK/JKEENAN/'],
         'checksums': ['22e6f5222b505ee513058fdca35ab7a1eab80539b98e5ca4a923a70a8ae9ba9e'],
     }),
     ('Importer', '0.026', {
         'source_tmpl': 'Importer-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/E/EX/EXODIST/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST/'],
         'checksums': ['e08fa84e13cb998b7a897fc8ec9c3459fcc1716aff25cc343e36ef875891b0ef'],
     }),
     ('Term::Table', '0.016', {
         'source_tmpl': 'Term-Table-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/E/EX/EXODIST/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST/'],
         'checksums': ['8fb4fbb8e96a2d6c514949eb8cfd7e66319bcb1cbf7cea0ab19af887a72d97bf'],
     }),
     ('Scope::Guard', '0.21', {
         'source_tmpl': 'Scope-Guard-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/C/CH/CHOCOLATE/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/C/CH/CHOCOLATE/'],
         'checksums': ['8c9b1bea5c56448e2c3fadc65d05be9e4690a3823a80f39d2f10fdd8f777d278'],
     }),
     ('Sub::Info', '0.002', {
         'source_tmpl': 'Sub-Info-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/E/EX/EXODIST/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST/'],
         'checksums': ['ea3056d696bdeff21a99d340d5570887d39a8cc47bff23adfc82df6758cdd0ea'],
     }),
     ('Test2::Require::Module', '0.000145', {
         'source_tmpl': 'Test2-Suite-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/E/EX/EXODIST/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST/'],
         'checksums': ['ed44be739c8879fe178d3107b238f2db960d52797db0058de53be5b84600358b'],
     }),
     ('Test2::Plugin::NoWarnings', '0.09', {
         'source_tmpl': 'Test2-Plugin-NoWarnings-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/D/DR/DROLSKY/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/'],
         'checksums': ['be3dd800042eef362bf17d2056cf9e934dee91ccce98e4f178b8fb5772f2fb74'],
     }),
     ('Class::Tiny', '1.008', {
         'source_tmpl': 'Class-Tiny-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/D/DA/DAGOLDEN/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/'],
         'checksums': ['ee058a63912fa1fcb9a72498f56ca421a2056dc7f9f4b67837446d6421815615'],
     }),
     ('Test::File::ShareDir::Dist', '1.001002', {
         'source_tmpl': 'Test-File-ShareDir-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/K/KE/KENTNL/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/K/KE/KENTNL/'],
         'checksums': ['b33647cbb4b2f2fcfbde4f8bb4383d0ac95c2f89c4c5770eb691f1643a337aad'],
     }),
     ('DateTime::Locale', '1.35', {
@@ -210,12 +210,12 @@ exts_list = [
     }),
     ('CPAN::Meta::Check', '0.014', {
         'source_tmpl': 'CPAN-Meta-Check-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/L/LE/LEONT/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT/'],
         'checksums': ['28a0572bfc1c0678d9ce7da48cf521097ada230f96eb3d063fcbae1cfe6a351f'],
     }),
     ('Test::Without::Module', '0.20', {
         'source_tmpl': 'Test-Without-Module-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/C/CO/CORION/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/C/CO/CORION/'],
         'checksums': ['8e9aeb7c32a6c6d0b8a93114db2a8c072721273a9d9a2dd4f9ca86cfd28aa524'],
     }),
     ('DateTime', '1.58', {
@@ -1051,7 +1051,7 @@ exts_list = [
     }),
     ('Test::Needs', '0.002009', {
         'source_tmpl': 'Test-Needs-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/H/HA/HAARG/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/H/HA/HAARG/'],
         'checksums': ['571c21193ad16195df58b06b268798796a391b398c443271721d2cc0fb7c4ac3'],
     }),
     ('HTTP::Daemon', '6.14', {
@@ -1131,12 +1131,12 @@ exts_list = [
     }),
     ('Module::Runtime::Conflicts', '0.003', {
         'source_tmpl': 'Module-Runtime-Conflicts-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/E/ET/ETHER/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER/'],
         'checksums': ['707cdc75038c70fe91779b888ac050f128565d3967ba96680e1b1c7cc9733875'],
     }),
     ('Test::CleanNamespaces', '0.24', {
         'source_tmpl': 'Test-CleanNamespaces-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/E/ET/ETHER/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER/'],
         'checksums': ['338d5569e8e89a654935f843ec0bc84aaa486fe8dd1898fb9cab3eccecd5327a'],
     }),
     ('Moose', '2.2201', {
@@ -1221,7 +1221,7 @@ exts_list = [
     }),
     ('Test::More::UTF8', '0.05', {
         'source_tmpl': 'Test-More-UTF8-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/M/MO/MONS/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MO/MONS/'],
         'checksums': ['b9f1c4b36a97cdfefaa53ed1115dd38f4b483037775f6559ee1df14acfd1ce04'],
     }),
     ('Text::Template', '1.60', {
@@ -1231,17 +1231,17 @@ exts_list = [
     }),
     ('PadWalker', '2.5', {
         'source_tmpl': 'PadWalker-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/R/RO/ROBIN/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RO/ROBIN/'],
         'checksums': ['07b26abb841146af32072a8d68cb90176ffb176fd9268e6f2f7d106f817a0cd0'],
     }),
     ('Devel::Cycle', '1.12', {
         'source_tmpl': 'Devel-Cycle-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/L/LD/LDS/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/L/LD/LDS/'],
         'checksums': ['fd3365c4d898b2b2bddbb78a46d507a18cca8490a290199547dab7f1e7390bc2'],
     }),
     ('Test::Memory::Cycle', '1.06', {
         'source_tmpl': 'Test-Memory-Cycle-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/P/PE/PETDANCE/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PE/PETDANCE/'],
         'checksums': ['9d53ddfdc964cd8454cb0da4c695b6a3ae47b45839291c34cb9d8d1cfaab3202'],
     }),
     ('PDF::API2', '2.043', {
@@ -1301,12 +1301,12 @@ exts_list = [
     }),
     ('Set::Object', '1.42', {
         'source_tmpl': 'Set-Object-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/R/RU/RURBAN/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RU/RURBAN/'],
         'checksums': ['d18c5a8a233eabbd0206cf3da5b00fcdd7b37febf12a93dcc3d1c026e6fdec45'],
     }),
     ('Heap', '0.80', {
         'source_tmpl': 'Heap-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/J/JM/JMM/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/J/JM/JMM/'],
         'checksums': ['ccda29f3c93176ad0fdfff4dd6f5e4ac90b370cba4b028386b7343bf64139bde'],
     }),
     ('Graph', '0.9725', {
@@ -1376,7 +1376,7 @@ exts_list = [
     }),
     ('Variable::Magic', '0.62', {
         'source_tmpl': 'Variable-Magic-%(version)s.tar.gz',
-        'source_urls': ['https://www.cpan.org/authors/id/V/VP/VPIT/'],
+        'source_urls': ['https://cpan.metacpan.org/authors/id/V/VP/VPIT/'],
         'checksums': ['3f9a18517e33f006a9c2fc4f43f01b54abfe6ff2eae7322424f31069296b615c'],
     }),
     ('B::Hooks::EndOfScope', '0.26', {


### PR DESCRIPTION
Changed Perl module source URLs from cpan to metacpan, because some older versions are no longer available from cpan, but can be downloaded from metacpan.