### PR TITLE
feat:add vip-v8.4.0.eb

### DIFF
--- a/v/vip/vip-v8.4.0.eb
+++ b/v/vip/vip-v8.4.0.eb
@@ -1,0 +1,35 @@
+easyblock = 'Tarball'
+
+name = 'vip'
+version = 'v8.4.0'
+
+homepage = 'https://vip.molgeniscloud.org/'
+description = """Variant Interpretation Pipeline"""
+
+toolchain = {'name': 'system', 'version': ''}
+
+dependencies = [
+    ('Java', '21-LTS'),
+]
+
+#
+# run VIP installer
+#
+postinstallcmds = [
+    'curl -sSL https://raw.githubusercontent.com/molgenis/%(name)s/refs/tags/%(version)s/install.sh | VIP_DIR="/apps/software/%(name)s/%(version)s" VIP_DIR_DATA="/apps/data/%(name)s" bash',
+    '(cd /apps/software/%(name)s/%(version)s && ln --symbolic "vip.sh" "vip")',
+]
+
+sanity_check_paths = {
+    'files': ['vip.sh', 'vip'],
+    'dirs': ['/apps/data/%(name)s/resources', '/apps/data/%(name)s/images']
+}
+
+modextravars={
+    'VIP_DIR': '/apps/software/%(name)s/%(version)s',
+    'VIP_DIR_DATA': '/apps/data/%(name)s'
+}
+
+modextrapaths = {'PATH': '.'}
+
+moduleclass = 'bio'


### PR DESCRIPTION
```
running tests ...
cram/complex                             | PASSED | 392641=completed vip/v8.4.0/test/output/cram/complex/.nxf.log
cram/multiproject                        | PASSED | 392642=completed vip/v8.4.0/test/output/cram/multiproject/.nxf.log
cram/nanopore_duo                        | PASSED | 392643=completed vip/v8.4.0/test/output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 392644=completed vip/v8.4.0/test/output/cram/nanopore/.nxf.log
cram/single                              | PASSED | 392645=completed vip/v8.4.0/test/output/cram/single/.nxf.log
cram/trio                                | PASSED | 392646=completed vip/v8.4.0/test/output/cram/trio/.nxf.log
fastq/nanopore_adaptive_sampling         | PASSED | 392647=completed vip/v8.4.0/test/output/fastq/nanopore_adaptive_sampling/.nxf.log
fastq/nanopore                           | PASSED | 392648=completed vip/v8.4.0/test/output/fastq/nanopore/.nxf.log
fastq/pacbio_hifi                        | PASSED | 392649=completed vip/v8.4.0/test/output/fastq/pacbio_hifi/.nxf.log
gvcf/liftover                            | PASSED | 392650=completed vip/v8.4.0/test/output/gvcf/liftover/.nxf.log
gvcf/multiproject                        | PASSED | 392651=completed vip/v8.4.0/test/output/gvcf/multiproject/.nxf.log
gvcf/trio                                | PASSED | 392652=completed vip/v8.4.0/test/output/gvcf/trio/.nxf.log
vcf/aip                                  | PASSED | 392653=completed vip/v8.4.0/test/output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 392654=completed vip/v8.4.0/test/output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 392655=completed vip/v8.4.0/test/output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 392656=completed vip/v8.4.0/test/output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 392657=completed vip/v8.4.0/test/output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 392658=completed vip/v8.4.0/test/output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 392659=completed vip/v8.4.0/test/output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 392660=completed vip/v8.4.0/test/output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 392661=completed vip/v8.4.0/test/output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 392662=completed vip/v8.4.0/test/output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 392663=completed vip/v8.4.0/test/output/vcf/mvid/.nxf.log
vcf/no_spliceai                          | PASSED | 392664=completed vip/v8.4.0/test/output/vcf/no_spliceai/.nxf.log
vcf/str                                  | PASSED | 392665=completed vip/v8.4.0/test/output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 392666=completed vip/v8.4.0/test/output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 392667=completed vip/v8.4.0/test/output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 392668=completed vip/v8.4.0/test/output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 392669=completed vip/v8.4.0/test/output/vcf/vkgl_vus/.nxf.log
done
```