### PR TITLE
Bugfix for existing R *-bare easyconfigs.

### DIFF
--- a/r/R/R-4.2.1-foss-2022a-bare.eb
+++ b/r/R/R-4.2.1-foss-2022a-bare.eb
@@ -52,6 +52,12 @@ dependencies = [
 
 #osdependencies = [OS_PKG_OPENSSL_DEV]
 
+#
+# Add the standard math library to FLIBS for R packages with Fortran code (e.g. mclust, quantreg and waveslim)
+# to avoid "Error: package or namespace load failed" due to "undefined symbols".
+#
+preconfigopts = 'export FLIBS="$FLIBS -lm" && '
+
 configopts = '--with-pic --enable-threads --enable-R-shlib'
 #
 # Bare R version. Additional packages go into RPlus.

--- a/r/R/R-4.2.2-foss-2022a-bare.eb
+++ b/r/R/R-4.2.2-foss-2022a-bare.eb
@@ -52,6 +52,12 @@ dependencies = [
 
 #osdependencies = [OS_PKG_OPENSSL_DEV]
 
+#
+# Add the standard math library to FLIBS for R packages with Fortran code (e.g. mclust, quantreg and waveslim)
+# to avoid "Error: package or namespace load failed" due to "undefined symbols".
+#
+preconfigopts = 'export FLIBS="$FLIBS -lm" && '
+
 configopts = '--with-pic --enable-threads --enable-R-shlib'
 #
 # Bare R version. Additional packages go into RPlus.

--- a/r/R/R-4.4.0-foss-2022a-bare.eb
+++ b/r/R/R-4.4.0-foss-2022a-bare.eb
@@ -52,6 +52,12 @@ dependencies = [
 
 #osdependencies = [OS_PKG_OPENSSL_DEV]
 
+#
+# Add the standard math library to FLIBS for R packages with Fortran code (e.g. mclust, quantreg and waveslim)
+# to avoid "Error: package or namespace load failed" due to "undefined symbols".
+#
+preconfigopts = 'export FLIBS="$FLIBS -lm" && '
+
 configopts = '--with-pic --enable-threads --enable-R-shlib'
 #
 # Bare R version. Additional packages go into RPlus.

--- a/r/R/R-4.4.2-foss-2022a-bare.eb
+++ b/r/R/R-4.4.2-foss-2022a-bare.eb
@@ -52,6 +52,12 @@ dependencies = [
 
 #osdependencies = [OS_PKG_OPENSSL_DEV]
 
+#
+# Add the standard math library to FLIBS for R packages with Fortran code (e.g. mclust, quantreg and waveslim)
+# to avoid "Error: package or namespace load failed" due to "undefined symbols".
+#
+preconfigopts = 'export FLIBS="$FLIBS -lm" && '
+
 configopts = '--with-pic --enable-threads --enable-R-shlib'
 #
 # Bare R version. Additional packages go into RPlus.


### PR DESCRIPTION
Include standard math library in environment when compiling Fortran code to prevent "undefined symbol" errors.